### PR TITLE
Fix Pokemon enum typo

### DIFF
--- a/agent/memory_reader.py
+++ b/agent/memory_reader.py
@@ -252,7 +252,7 @@ class Pokemon(IntEnum):
     NIDORINA = 0xA8
     GEODUDE = 0xA9
     PORYGON = 0xAA
-    AERODACTYL = 0xABAA
+    AERODACTYL = 0xAB
     MISSINGNO_AC = 0xAC
     MAGNEMITE = 0xAD
     MISSINGNO_AE = 0xAE


### PR DESCRIPTION
## Summary
- fix mis-typed value for `AERODACTYL` in `Pokemon` enum

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68460eac060c832799467b265c97dc05