### PR TITLE
Fix end_input default

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -216,7 +216,7 @@ class OnScreenKeyboardTool(Tool):
         """Process a keyboard_input tool call."""
         tool_input = json.loads(tool_call.function.arguments)
         text = tool_input["text"]
-        end_input = tool_input.get("end_input", False)
+        end_input = tool_input.get("end_input", True)
 
         logger.info(f"[Keyboard] Inputting text: '{text}' (end_input={end_input})")
 


### PR DESCRIPTION
## Summary
- ensure `OnScreenKeyboardTool.process` matches the documented default for `end_input`

## Testing
- `ruff check agent/tools.py | head`

------
https://chatgpt.com/codex/tasks/task_e_684611481edc8327bcd0e29d61b0ed36