### PR TITLE
Update steps default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ python main.py
 
 Optional arguments:
 - `--rom`: Path to the Pokemon ROM file (default: `pokemon.gb` in the root directory)
-- `--steps`: Number of agent steps to run (default: 10)
+- `--steps`: Number of agent steps to run (default: 250)
 - `--display`: Run with display (not headless)
 - `--sound`: Enable sound (only applicable with display)
 


### PR DESCRIPTION
## Summary
- correct the `--steps` default in README

## Testing
- `ruff check .` *(fails: E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_6846115f76b08327ac1f00f9f60733c5