### PR TITLE
Add test for OnScreenKeyboardTool

### DIFF
--- a/agent/tools.py
+++ b/agent/tools.py
@@ -216,7 +216,7 @@ class OnScreenKeyboardTool(Tool):
         """Process a keyboard_input tool call."""
         tool_input = json.loads(tool_call.function.arguments)
         text = tool_input["text"]
-        end_input = tool_input.get("end_input", False)
+        end_input = tool_input.get("end_input", True)
 
         logger.info(f"[Keyboard] Inputting text: '{text}' (end_input={end_input})")
 

--- a/tests/test_on_screen_keyboard.py
+++ b/tests/test_on_screen_keyboard.py
@@ -1,0 +1,71 @@
+import json
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+openai_module = types.ModuleType("openai")
+openai_types = types.ModuleType("openai.types")
+openai_chat = types.ModuleType("openai.types.chat")
+
+class ChatCompletionMessageToolCall:
+    def __init__(self, id, function):
+        self.id = id
+        self.function = function
+
+
+ChatCompletionToolMessageParam = dict
+
+openai_chat.ChatCompletionMessageToolCall = ChatCompletionMessageToolCall
+openai_chat.ChatCompletionToolMessageParam = ChatCompletionToolMessageParam
+openai_types.chat = openai_chat
+openai_module.types = openai_types
+sys.modules.setdefault("openai", openai_module)
+sys.modules.setdefault("openai.types", openai_types)
+sys.modules.setdefault("openai.types.chat", openai_chat)
+
+emulator_module = types.ModuleType("agent.emulator")
+class Emulator:
+    pass
+emulator_module.Emulator = Emulator
+sys.modules.setdefault("agent.emulator", emulator_module)
+
+from agent.tools import OnScreenKeyboardTool
+
+
+class DummyEmulator:
+    def __init__(self):
+        self.presses = []
+
+    def press_buttons(self, buttons, wait=True):
+        self.presses.append((list(buttons), wait))
+
+
+def make_tool_call(arguments: dict):
+    return SimpleNamespace(
+        id="test_call",
+        function=SimpleNamespace(arguments=json.dumps(arguments)),
+    )
+
+
+def test_keyboard_default_end():
+    emulator = DummyEmulator()
+    tool = OnScreenKeyboardTool(emulator)
+    tool_call = make_tool_call({"text": "A"})
+
+    tool.process(tool_call)
+
+    # expected sequence: select 'A', move to END, press 'A' again
+    expected = []
+    # select 'A'
+    expected.append((["a"], True))
+    # move right 8 times to column 8
+    expected.extend(((["right"], True) for _ in range(8)))
+    # move down 4 times to row 4
+    expected.extend(((["down"], True) for _ in range(4)))
+    # press 'a' to select END
+    expected.append((["a"], True))
+
+    assert emulator.presses == expected


### PR DESCRIPTION
## Summary
- add unit test verifying that OnScreenKeyboardTool selects `END` when `end_input` is omitted
- fix default value in `OnScreenKeyboardTool.process`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846116795c08327ac61718f5775e306